### PR TITLE
Adding `fn/cva` helper function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
         "phpunit/phpunit": "^10.3.2"
     },
     "autoload": {
+        "files": [
+            "src/helpers.php"
+        ],
         "psr-4": {
             "FeatureNinja\\Cva\\": "src/"
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace fn;
+
+use FeatureNinja\Cva\ClassVarianceAuthority;
+
+/**
+ * @param string|array<int, string> $base
+ * @param array{
+ *     variants?: array<string, array<string, string|array<int, string>>>,
+ *     compoundVariants?: array<int, array<string, string>>,
+ *     defaultVariants?: array<string, string>
+ * } $config
+ */
+function cva(string|array $base, array $config): ClassVarianceAuthority
+{
+    return ClassVarianceAuthority::new($base, $config);
+}


### PR DESCRIPTION
In simple projects my definitions often just live in my view files and it always bugged me to type the FQCN when using cva.
These changes add the `fn\cva` helper which accepts the same parameters as the `FeatureNinja\Cva\ClassVarianceAuthority::new` method.

```php
$button = fn\cva(
    ['font-semibold', 'border', 'rounded'],
    [
        'variants' => [
            'intent' => [
                'primary' => ['bg-blue-500', 'text-white', 'border-transparent', 'hover:bg-blue-600'],
                'secondary' => 'bg-white text-gray-800 border-gray-400 hover:bg-gray-100',
            ],
            'size' => [
                'small' => ['text-sm', 'py-1', 'px-2'],
                'medium' => 'text-base py-2 px-4',
            ],
        ],
        'compoundVariants' => [
            [
                'intent' => 'primary',
                'size' => 'medium',
                'class' => 'uppercase',
            ],
        ],
        'defaultVariants' => [
            'intent' => 'primary',
            'size' => 'medium',
        ],
    ],
);
```