### PR TITLE
Allow passing additional class names

### DIFF
--- a/src/ClassVarianceAuthority.php
+++ b/src/ClassVarianceAuthority.php
@@ -35,9 +35,12 @@ final readonly class ClassVarianceAuthority
     {
         $props = $this->config->defaultVariants->merge($props);
 
+        $additionalClassNames = ClassNames::of($props['class'] ?? $props['className'] ?? '');
+
         return $this->base
             ->concat($this->config->variants->resolve($props))
             ->concat($this->config->compoundVariants->resolve($props))
+            ->concat($additionalClassNames)
             ->toString();
     }
 }

--- a/src/ClassVarianceAuthorityTest.php
+++ b/src/ClassVarianceAuthorityTest.php
@@ -50,5 +50,15 @@ final class ClassVarianceAuthorityTest extends TestCase
             'font-semibold border rounded bg-white text-gray-800 border-gray-400 hover:bg-gray-100 text-sm py-1 px-2',
             $button(['intent' => 'secondary', 'size' => 'small']),
         );
+
+        $this->assertSame(
+            'font-semibold border rounded bg-white text-gray-800 border-gray-400 hover:bg-gray-100 text-sm py-1 px-2 focus:ring-2',
+            $button(['class' => 'focus:ring-2', 'className' => 'focus:ring-4', 'intent' => 'secondary', 'size' => 'small']),
+        );
+
+        $this->assertSame(
+            'font-semibold border rounded bg-white text-gray-800 border-gray-400 hover:bg-gray-100 text-sm py-1 px-2 focus:ring-2',
+            $button(['className' => 'focus:ring-2', 'intent' => 'secondary', 'size' => 'small']),
+        );
     }
 }


### PR DESCRIPTION
Allows `'class'` or `'className'` to be passed when building class names. When both are passed `'class'` has precedence.

```php
$button = fn\cva(
    ['font-semibold', 'border', 'rounded'],
    [
        'variants' => [
            'intent' => [
                'primary' => ['bg-blue-500', 'text-white', 'border-transparent', 'hover:bg-blue-600'],
                'secondary' => 'bg-white text-gray-800 border-gray-400 hover:bg-gray-100',
            ],
            'size' => [
                'small' => ['text-sm', 'py-1', 'px-2'],
                'medium' => 'text-base py-2 px-4',
            ],
        ],
        'compoundVariants' => [
            [
                'intent' => 'primary',
                'size' => 'medium',
                'class' => 'uppercase',
            ],
        ],
        'defaultVariants' => [
            'intent' => 'primary',
            'size' => 'medium',
        ],
    ],
);

$button(['class' => 'text-green']);
$button(['className' => 'text-green']);
```