### PR TITLE
chores: Update the readme to include cva helper function usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $button = ClassVarianceAuthority::new(
 
 # Or by using the cva helper function
 
-$button = cva(
+$button = fn\cva(
     ['font-semibold', 'border', 'rounded'],
     [
         'variants' => [

--- a/README.md
+++ b/README.md
@@ -45,6 +45,35 @@ $button = ClassVarianceAuthority::new(
         ],
     ],
 );
+
+# Or by using the cva helper function
+
+$button = cva(
+    ['font-semibold', 'border', 'rounded'],
+    [
+        'variants' => [
+            'intent' => [
+                'primary' => ['bg-blue-500', 'text-white', 'border-transparent', 'hover:bg-blue-600'],
+                'secondary' => 'bg-white text-gray-800 border-gray-400 hover:bg-gray-100',
+            ],
+            'size' => [
+                'small' => ['text-sm', 'py-1', 'px-2'],
+                'medium' => 'text-base py-2 px-4',
+            ],
+        ],
+        'compoundVariants' => [
+            [
+                'intent' => 'primary',
+                'size' => 'medium',
+                'class' => 'uppercase',
+            ],
+        ],
+        'defaultVariants' => [
+            'intent' => 'primary',
+            'size' => 'medium',
+        ],
+    ],
+);
 ```
 
 ```html


### PR DESCRIPTION
I'm opening this pull request to add the usage of the `cva` helper function as an alternative to using the `FeatureNinja\Cva\ClassVarianceAuthority` for anyone who prefers using helpers instead of classes. 

What changed:

- README.md
